### PR TITLE
Add gc.info wrapper

### DIFF
--- a/docs/library/gc.rst
+++ b/docs/library/gc.rst
@@ -64,3 +64,14 @@ Functions
       This function is a MicroPython extension. CPython has a similar
       function - ``set_threshold()``, but due to different GC
       implementations, its signature and semantics are different.
+
+.. function:: info()
+
+   Return a tuple ``(total, used, free, max_free, num_1block, num_2block, max_block[, max_new_split])``
+   describing the current state of the heap. The optional ``max_new_split``
+   value is included only when ``MICROPY_GC_SPLIT_HEAP_AUTO`` is enabled.
+
+   .. admonition:: Difference to CPython
+      :class: attention
+
+      This function is a MicroPython extension.

--- a/py/modgc.c
+++ b/py/modgc.c
@@ -81,6 +81,37 @@ static mp_obj_t gc_mem_alloc(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_mem_alloc_obj, gc_mem_alloc);
 
+// info(): return a tuple with GC state information
+static mp_obj_t gc_info_wrapper(void) {
+    gc_info_t info;
+    gc_info(&info);
+#if MICROPY_GC_SPLIT_HEAP_AUTO
+    mp_obj_t tuple[8] = {
+        mp_obj_new_int_from_uint(info.total),
+        mp_obj_new_int_from_uint(info.used),
+        mp_obj_new_int_from_uint(info.free),
+        mp_obj_new_int_from_uint(info.max_free),
+        mp_obj_new_int_from_uint(info.num_1block),
+        mp_obj_new_int_from_uint(info.num_2block),
+        mp_obj_new_int_from_uint(info.max_block),
+        mp_obj_new_int_from_uint(info.max_new_split),
+    };
+    return mp_obj_new_tuple(8, tuple);
+#else
+    mp_obj_t tuple[7] = {
+        mp_obj_new_int_from_uint(info.total),
+        mp_obj_new_int_from_uint(info.used),
+        mp_obj_new_int_from_uint(info.free),
+        mp_obj_new_int_from_uint(info.max_free),
+        mp_obj_new_int_from_uint(info.num_1block),
+        mp_obj_new_int_from_uint(info.num_2block),
+        mp_obj_new_int_from_uint(info.max_block),
+    };
+    return mp_obj_new_tuple(7, tuple);
+#endif
+}
+MP_DEFINE_CONST_FUN_OBJ_0(gc_info_obj, gc_info_wrapper);
+
 #if MICROPY_GC_ALLOC_THRESHOLD
 static mp_obj_t gc_threshold(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
@@ -108,9 +139,10 @@ static const mp_rom_map_elem_t mp_module_gc_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isenabled), MP_ROM_PTR(&gc_isenabled_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_free), MP_ROM_PTR(&gc_mem_free_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_alloc), MP_ROM_PTR(&gc_mem_alloc_obj) },
-    #if MICROPY_GC_ALLOC_THRESHOLD
+    { MP_ROM_QSTR(MP_QSTR_info), MP_ROM_PTR(&gc_info_obj) },
+#if MICROPY_GC_ALLOC_THRESHOLD
     { MP_ROM_QSTR(MP_QSTR_threshold), MP_ROM_PTR(&gc_threshold_obj) },
-    #endif
+#endif
 };
 
 static MP_DEFINE_CONST_DICT(mp_module_gc_globals, mp_module_gc_globals_table);

--- a/tests/basics/gc_info.py
+++ b/tests/basics/gc_info.py
@@ -1,0 +1,10 @@
+import gc
+
+if not hasattr(gc, "info"):
+    print("SKIP")
+    raise SystemExit
+
+info = gc.info()
+print(isinstance(info, tuple))
+print(len(info) >= 7)
+print(info[0] == info[1] + info[2])

--- a/tests/basics/gc_info.py.exp
+++ b/tests/basics/gc_info.py.exp
@@ -1,0 +1,3 @@
+True
+True
+True


### PR DESCRIPTION
## Summary
- expose `gc.info()` with GC stats
- document the new API in gc module docs
- add a basic test for gc.info

## Testing
- `make -C mpy-cross`
- `make -C ports/unix VARIANT=minimal -j$(nproc)` *(fails to include gc module, tests fail)*
- `MICROPY_MICROPYTHON=../ports/unix/build-minimal/micropython python3 run-tests.py basics/gc_info.py` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fbce465483319981c63a7ebc200a