### PR TITLE
Expose GC info dictionary and split-heap docs

### DIFF
--- a/docs/library/gc.rst
+++ b/docs/library/gc.rst
@@ -67,11 +67,50 @@ Functions
 
 .. function:: info()
 
-   Return a tuple ``(total, used, free, max_free, num_1block, num_2block, max_block[, max_new_split])``
-   describing the current state of the heap. The optional ``max_new_split``
-   value is included only when ``MICROPY_GC_SPLIT_HEAP_AUTO`` is enabled.
+   Return a dictionary describing the current state of the heap with
+   the following fields:
+
+   ``total``
+       Total heap size in bytes.
+
+   ``used``
+       Currently allocated bytes.
+
+   ``free``
+       Free bytes in the heap.
+
+   ``max_free``
+       Size of the largest contiguous free block.
+
+   ``num_1block`` ``num_2block``
+       Number of 1 and 2 block fragments.
+
+   ``max_block``
+       Maximum allocatable block size.
+
+   When ``MICROPY_GC_SPLIT_HEAP_AUTO`` is enabled an additional
+   ``max_new_split`` field is present.
+
+   Example usage::
+
+       >>> import gc
+       >>> gc.info()
+       {'total': 8504576, 'used': 102400, 'free': 8402176,
+        'max_free': 5000000, 'num_1block': 5, 'num_2block': 2, 'max_block': 3000000}
 
    .. admonition:: Difference to CPython
       :class: attention
 
       This function is a MicroPython extension.
+
+.. rubric:: GC mark-stack overflow
+
+When the number of objects to mark during a collection exceeds
+``MICROPY_ALLOC_GC_STACK_SIZE`` (default value is 64) the flag
+``gc_stack_overflow`` is set and the collector performs a full heap
+rescan instead of aborting the collection.
+
+If this overflow occurs often consider increasing
+``MICROPY_ALLOC_GC_STACK_SIZE`` in ``mpconfigport.h``::
+
+    #define MICROPY_ALLOC_GC_STACK_SIZE 128

--- a/docs/renesas-ra/split-heap.md
+++ b/docs/renesas-ra/split-heap.md
@@ -1,0 +1,19 @@
+# Split-heap конфигурация за RA6M5
+
+За да използвате и външната OSPI RAM, добавете в `main.c`:
+
+```c
+extern char _heap_internal_start, _heap_internal_end;
+extern char _ospi_ram_start, _ospi_ram_end;
+
+gc_init(&_heap_internal_start, &_heap_internal_end);
+gc_init(&_ospi_ram_start, &_ospi_ram_end);
+```
+
+След компилация проверете с:
+
+```python
+import gc; print(gc.info())
+```
+
+трите полета `total`, `free` и `max_block` трябва да отчитат двата региона.

--- a/ports/renesas-ra/main.c
+++ b/ports/renesas-ra/main.c
@@ -64,6 +64,12 @@
 #include "usrsw.h"
 #include "rtc.h"
 #include "storage.h"
+#if MICROPY_ENABLE_GC
+extern char _heap_internal_start, _heap_internal_end;
+#if MICROPY_HW_HAS_OSPI_RAM
+extern char _ospi_ram_start, _ospi_ram_end;
+#endif
+#endif
 #if MICROPY_PY_LWIP
 #include "lwip/init.h"
 #include "lwip/apps/mdns.h"
@@ -310,14 +316,9 @@ soft_reset:
 
     // GC init
     #if MICROPY_ENABLE_GC
-    gc_init(MICROPY_HEAP_START, MICROPY_HEAP_END);
-    #if MICROPY_GC_SPLIT_HEAP
-    assert(MICROPY_GC_SPLIT_HEAP_N_HEAPS > 0);
+    gc_init(&_heap_internal_start, &_heap_internal_end);
     #if MICROPY_HW_HAS_OSPI_RAM
-    if (FSP_SUCCESS == R_OSPI_Open(&g_ospi_ram0_ctrl, &g_ospi_ram0_cfg)) {
-        gc_add(MICROPY_EXTRA_HEAP_START, MICROPY_EXTRA_HEAP_END);
-    }
-    #endif
+    gc_init(&_ospi_ram_start, &_ospi_ram_end);
     #endif
     #endif
 

--- a/py/gc.c
+++ b/py/gc.c
@@ -438,6 +438,7 @@ static void gc_mark_subtree(size_t block)
                 #endif
                 sp += 1;
             } else {
+                // Mark-stack overflowed, signal for a full heap rescan.
                 MP_STATE_MEM(gc_stack_overflow) = 1;
             }
         }
@@ -456,6 +457,8 @@ static void gc_mark_subtree(size_t block)
     }
 }
 
+// When gc_stack_overflow is set, perform a full rescan of the heap to
+// ensure all reachable objects are marked.
 static void gc_deal_with_stack_overflow(void) {
     while (MP_STATE_MEM(gc_stack_overflow)) {
         MP_STATE_MEM(gc_stack_overflow) = 0;

--- a/py/modgc.c
+++ b/py/modgc.c
@@ -82,35 +82,32 @@ static mp_obj_t gc_mem_alloc(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(gc_mem_alloc_obj, gc_mem_alloc);
 
 // info(): return a tuple with GC state information
-static mp_obj_t gc_info_wrapper(void) {
+STATIC mp_obj_t gc_info(void) {
     gc_info_t info;
     gc_info(&info);
-#if MICROPY_GC_SPLIT_HEAP_AUTO
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int_from_uint(info.total),
-        mp_obj_new_int_from_uint(info.used),
-        mp_obj_new_int_from_uint(info.free),
-        mp_obj_new_int_from_uint(info.max_free),
-        mp_obj_new_int_from_uint(info.num_1block),
-        mp_obj_new_int_from_uint(info.num_2block),
-        mp_obj_new_int_from_uint(info.max_block),
-        mp_obj_new_int_from_uint(info.max_new_split),
-    };
-    return mp_obj_new_tuple(8, tuple);
-#else
-    mp_obj_t tuple[7] = {
-        mp_obj_new_int_from_uint(info.total),
-        mp_obj_new_int_from_uint(info.used),
-        mp_obj_new_int_from_uint(info.free),
-        mp_obj_new_int_from_uint(info.max_free),
-        mp_obj_new_int_from_uint(info.num_1block),
-        mp_obj_new_int_from_uint(info.num_2block),
-        mp_obj_new_int_from_uint(info.max_block),
-    };
-    return mp_obj_new_tuple(7, tuple);
-#endif
+    #if MICROPY_GC_SPLIT_HEAP_AUTO
+    mp_obj_t dict = mp_obj_new_dict(8);
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_total), mp_obj_new_int_from_uint(info.total));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_used), mp_obj_new_int_from_uint(info.used));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_free), mp_obj_new_int_from_uint(info.free));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_max_free), mp_obj_new_int_from_uint(info.max_free));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_num_1block), mp_obj_new_int_from_uint(info.num_1block));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_num_2block), mp_obj_new_int_from_uint(info.num_2block));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_max_block), mp_obj_new_int_from_uint(info.max_block));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_max_new_split), mp_obj_new_int_from_uint(info.max_new_split));
+    #else
+    mp_obj_t dict = mp_obj_new_dict(7);
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_total), mp_obj_new_int_from_uint(info.total));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_used), mp_obj_new_int_from_uint(info.used));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_free), mp_obj_new_int_from_uint(info.free));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_max_free), mp_obj_new_int_from_uint(info.max_free));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_num_1block), mp_obj_new_int_from_uint(info.num_1block));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_num_2block), mp_obj_new_int_from_uint(info.num_2block));
+    mp_obj_dict_store(dict, MP_OBJ_NEW_QSTR(MP_QSTR_max_block), mp_obj_new_int_from_uint(info.max_block));
+    #endif
+    return dict;
 }
-MP_DEFINE_CONST_FUN_OBJ_0(gc_info_obj, gc_info_wrapper);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(gc_info_obj, gc_info);
 
 #if MICROPY_GC_ALLOC_THRESHOLD
 static mp_obj_t gc_threshold(size_t n_args, const mp_obj_t *args) {

--- a/tests/test_gc_info.py
+++ b/tests/test_gc_info.py
@@ -1,0 +1,6 @@
+import gc
+
+info = gc.info()
+assert isinstance(info, dict)
+assert 'total' in info and 'max_block' in info
+assert info['free'] + info['used'] == info['total']

--- a/tests/test_split_heap.py
+++ b/tests/test_split_heap.py
@@ -1,0 +1,5 @@
+import gc
+
+gc.collect()
+info = gc.info()
+assert info['max_block'] > 300 * 1024


### PR DESCRIPTION
## Summary
- expose detailed GC stats via `gc.info()`
- document GC mark‑stack overflow behaviour
- support OSPI split‑heap on RA6M5
- add tests for GC info and split heap examples

## Testing
- `ruff check .` *(fails: unrecognized subcommand)*
- `pytest tests/test_gc_info.py tests/test_split_heap.py` *(errors: module 'gc' has no attribute 'info')*

------
https://chatgpt.com/codex/tasks/task_e_684a072477b88331a00835458089d689